### PR TITLE
fix(react): calls getMyOrders after checkout only if user is logged in

### DIFF
--- a/client/components/stripeCheckout.js
+++ b/client/components/stripeCheckout.js
@@ -16,7 +16,7 @@ class Checkout extends React.Component {
         this.props.getNewCart(this.props.user.id); // gets new cart after changing status to created
       })
       .then(() => {
-        this.props.getMyOrders();
+        if (this.props.user.id) this.props.getMyOrders();
       })
       .then(() => {
         history.push('/home');


### PR DESCRIPTION
merge #125  before approving this one. It'll fix the PUT error that shows up on this branch. All this does is check if user exists before fetching ordering history after checkout. Connects to #127 Closes #127