### PR TITLE
refactor(currentProduct): add `removeCurrentProduct` action that clea…

### DIFF
--- a/client/components/singleProduct.js
+++ b/client/components/singleProduct.js
@@ -9,7 +9,8 @@ import {
   fetchCurrentProduct,
   addItemThunk,
   changeItemQuantityThunk,
-  getCartThunk
+  getCartThunk,
+  removeCurrentProduct
 } from '../store';
 
 class SingleProduct extends Component {
@@ -17,7 +18,9 @@ class SingleProduct extends Component {
     this.props.setCurrentProduct(this.props.match.params.productId);
     this.props.createUnauthCart();
   }
-
+  componentWillUnmount() {
+    this.props.removeCurrentProduct();
+  }
   render() {
     const singleProduct = this.props.currentProduct;
     const cart = this.props.cart;
@@ -95,6 +98,9 @@ const mapDispatchToProps = dispatch => ({
   createUnauthCart: () => {
     let cart = JSON.parse(localStorage.getItem('reduxState')).cart.id;
     if (!cart) dispatch(getCartThunk(null, {}));
+  },
+  removeCurrentProduct: () => {
+    dispatch(removeCurrentProduct())
   }
 });
 

--- a/client/store/currentProduct.js
+++ b/client/store/currentProduct.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 const GET_CURRENT_PRODUCT = 'GET_CURRENT_PRODUCT';
 const ADD_REVIEW = 'ADD_REVIEW';
+const REMOVE_CURRENT_PRODUCT = 'REMOVE_CURRENT_PRODUCT';
 
 const getCurrentProduct = currentProduct => ({
   type: GET_CURRENT_PRODUCT,
@@ -9,6 +10,8 @@ const getCurrentProduct = currentProduct => ({
 });
 
 const addReview = review => ({ type: ADD_REVIEW, review });
+
+export const removeCurrentProduct = () => ({ type: REMOVE_CURRENT_PRODUCT });
 
 // THUNK!
 export const fetchCurrentProduct = productId => dispatch => {
@@ -34,6 +37,8 @@ export default function(state = {}, action) {
       return action.currentProduct;
     case ADD_REVIEW:
       return { ...state, reviews: [...state.reviews, action.review] };
+    case REMOVE_CURRENT_PRODUCT:
+      return {};
     default:
       return state;
   }


### PR DESCRIPTION
…rs the current product piece of state when a user navigates away from the singleProduct component

When a user visits the `singleProduct` component for a second time, they will see the product that they viewed previous for a brief section before the current product loads. This is because the previous product is still set as the `currentProduct` on the state.

This branch sets the `currentProduct` state equal to an empty object when the `singleProduct` component unmounts. A user will no longer see the previous product on the `singleProduct` page when they click a new product.